### PR TITLE
Add Go DL/T 645 meter data acquisition server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,24 @@
 3.vs版本为2015
 
 4.本demo为钱姓开发者提供，在此对他表示感谢
+## Go DL/T 645 示例
+
+本仓库额外提供基于 Go 语言的 DL/T 645 协议采集示例，位于 `pkg/dlt645` 和 `cmd/dlt645server` 目录。
+
+### 运行示例
+
+1. 修改 `config.yaml` 中的串口、波特率、电表地址及 Web 服务端口。
+2. 编译并运行服务端：
+
+```bash
+# 安装依赖并运行单元测试
+cd /workspace/suite-demo-c-
+go test ./...
+
+# 启动 Web 服务
+cd /workspace/suite-demo-c-/cmd/dlt645server
+go run . -config ../config.yaml
+```
+
+启动后可通过 `http://<RaspberryPiIP>:8080/energy?rate=peak` 访问峰段电量，`rate` 参数支持 `peak`、`flat`、`valley`。
+

--- a/cmd/dlt645server/main.go
+++ b/cmd/dlt645server/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"dlt645server/pkg/dlt645"
+	"github.com/tarm/serial"
+	"gopkg.in/yaml.v3"
+)
+
+// Config 用于读取配置文件
+// 包含串口信息和 WEB 服务端口
+// 样例见根目录的 config.yaml
+//
+// serial_port: /dev/ttyUSB0
+// baud_rate: 2400
+// address: 112233445566
+// server_port: 8080
+
+type Config struct {
+	SerialPort string `yaml:"serial_port"`
+	BaudRate   int    `yaml:"baud_rate"`
+	Address    string `yaml:"address"`
+	ServerPort int    `yaml:"server_port"`
+}
+
+func loadConfig(path string) (*Config, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func main() {
+	cfgPath := flag.String("config", "config.yaml", "配置文件路径")
+	flag.Parse()
+
+	cfg, err := loadConfig(*cfgPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	port, err := serial.OpenPort(&serial.Config{Name: cfg.SerialPort, Baud: cfg.BaudRate})
+	if err != nil {
+		log.Fatalf("open serial: %v", err)
+	}
+	meter := dlt645.NewMeter(port, cfg.Address)
+
+	http.HandleFunc("/energy", func(w http.ResponseWriter, r *http.Request) {
+		rateStr := r.URL.Query().Get("rate")
+		var rate dlt645.Rate
+		switch rateStr {
+		case "peak":
+			rate = dlt645.RatePeak
+		case "flat":
+			rate = dlt645.RateFlat
+		case "valley":
+			rate = dlt645.RateValley
+		default:
+			http.Error(w, "rate must be peak|flat|valley", http.StatusBadRequest)
+			return
+		}
+		val, err := meter.ReadEnergy(rate)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintf(w, "%.2f", val)
+	})
+
+	addr := fmt.Sprintf(":%d", cfg.ServerPort)
+	log.Printf("server listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+serial_port: /dev/ttyUSB0
+baud_rate: 2400
+address: 112233445566
+server_port: 8080

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module dlt645server
+
+go 1.20
+
+require (
+github.com/tarm/serial v0.0.0-20230807212015-9745e2daaa8e
+gopkg.in/yaml.v3 v3.0.1
+)
+

--- a/pkg/dlt645/frame.go
+++ b/pkg/dlt645/frame.go
@@ -1,0 +1,126 @@
+package dlt645
+
+import (
+	"encoding/hex"
+	"errors"
+)
+
+// Rate 表示费率类型
+// 1-尖峰、2-平段、3-谷段
+// 此处仅实现常见的三个费率
+// 如需扩展可继续添加枚举
+// 枚举值对应 DL/T 645 标准中的数据标识
+// 0x00000100 费率1(峰) ,0x00000200 费率2(平) ,0x00000300 费率3(谷)
+type Rate int
+
+const (
+	RatePeak   Rate = 1 // 峰
+	RateFlat   Rate = 2 // 平
+	RateValley Rate = 3 // 谷
+)
+
+var rateDataID = map[Rate]uint32{
+	RatePeak:   0x00000100,
+	RateFlat:   0x00000200,
+	RateValley: 0x00000300,
+}
+
+// BuildReadFrame 生成读取数据的报文
+// addr 为 12 位表地址(以 BCD 格式给出, 如 "112233445566")
+// dataID 为数据标识
+func BuildReadFrame(addr string, dataID uint32) ([]byte, error) {
+	addrBytes, err := encodeAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+	// 构建帧
+	frame := []byte{0x68}
+	frame = append(frame, addrBytes[:]...) // 地址
+	frame = append(frame, 0x68)
+	frame = append(frame, 0x11) // 控制码: 读数据
+	frame = append(frame, 0x04) // 数据长度: 4 字节数据标识
+	did := encodeDataID(dataID)
+	frame = append(frame, did...)
+	cs := checksum(frame)
+	frame = append(frame, cs, 0x16)
+	return frame, nil
+}
+
+// ParseEnergyResponse 解析电表返回的能量数据
+// frame 为完整的16进制帧
+// 返回值为 kWh
+func ParseEnergyResponse(frame []byte) (float64, error) {
+	if len(frame) < 16 { // 最小长度
+		return 0, errors.New("frame too short")
+	}
+	if frame[0] != 0x68 || frame[len(frame)-1] != 0x16 {
+		return 0, errors.New("frame format error")
+	}
+	if checksum(frame[:len(frame)-2]) != frame[len(frame)-2] {
+		return 0, errors.New("checksum error")
+	}
+	// 跳过固定头部: 68 + 地址6 + 68 + 控制码 + 长度
+	// 索引从第10字节开始即数据区
+	data := frame[10 : len(frame)-2]
+	if len(data) < 8 {
+		return 0, errors.New("data field too short")
+	}
+	// 数据字段前4字节为数据标识,后4字节为数值
+	decoded := make([]byte, len(data))
+	for i, b := range data {
+		decoded[i] = b - 0x33
+	}
+	val := bcdToFloat(decoded[4:8])
+	return val, nil
+}
+
+// encodeAddress 将 12 位 BCD 地址编码并倒序
+func encodeAddress(addr string) ([6]byte, error) {
+	var res [6]byte
+	if len(addr) != 12 {
+		return res, errors.New("address must be 12 digits")
+	}
+	for i := 0; i < 6; i++ {
+		pair := addr[2*(5-i) : 2*(5-i)+2]
+		b, err := hex.DecodeString(pair)
+		if err != nil {
+			return res, err
+		}
+		res[i] = b[0]
+	}
+	return res, nil
+}
+
+// encodeDataID 编码数据标识并 +0x33
+func encodeDataID(id uint32) []byte {
+	bs := []byte{byte(id), byte(id >> 8), byte(id >> 16), byte(id >> 24)}
+	for i := range bs {
+		bs[i] += 0x33
+	}
+	return bs
+}
+
+// checksum 计算校验和
+func checksum(data []byte) byte {
+	var cs byte
+	for _, b := range data {
+		cs += b
+	}
+	return cs
+}
+
+// bcdToFloat 将4字节 BCD(低位在前) 转换为浮点数,假定小数位2
+func bcdToFloat(bs []byte) float64 {
+	var digits [8]byte
+	for i := 0; i < 4; i++ {
+		b := bs[i]
+		digits[2*i] = b & 0x0F
+		digits[2*i+1] = b >> 4
+	}
+	// 逆序排列
+	n := 0
+	for i := 7; i >= 0; i-- {
+		n = n*10 + int(digits[i])
+	}
+	return float64(n) / 100.0
+}

--- a/pkg/dlt645/frame_test.go
+++ b/pkg/dlt645/frame_test.go
@@ -1,0 +1,65 @@
+package dlt645
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestBuildReadFrame(t *testing.T) {
+	frame, err := BuildReadFrame("112233445566", rateDataID[RatePeak])
+	if err != nil {
+		t.Fatalf("BuildReadFrame error: %v", err)
+	}
+	expected := []byte{0x68, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x68, 0x11, 0x04, 0x33, 0x34, 0x33, 0x33, 0x17, 0x16}
+	if !bytes.Equal(frame, expected) {
+		t.Fatalf("unexpected frame: %x", frame)
+	}
+}
+
+func TestParseEnergyResponse(t *testing.T) {
+	frame := []byte{0x68, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x68, 0x91, 0x08, 0x33, 0x34, 0x33, 0x33, 0x89, 0x67, 0x45, 0x33, 0x03, 0x16}
+	val, err := ParseEnergyResponse(frame)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if math.Abs(val-1234.56) > 0.01 {
+		t.Fatalf("expect 1234.56 got %f", val)
+	}
+}
+
+// stubPort 用于模拟串口设备
+type stubPort struct {
+	written []byte
+	reply   []byte
+}
+
+func (s *stubPort) Write(p []byte) (int, error) {
+	s.written = append(s.written, p...)
+	return len(p), nil
+}
+
+func (s *stubPort) Read(p []byte) (int, error) {
+	copy(p, s.reply)
+	return len(s.reply), nil
+}
+
+func (s *stubPort) Close() error { return nil }
+
+func TestMeterReadEnergy(t *testing.T) {
+	resp := []byte{0x68, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x68, 0x91, 0x08, 0x33, 0x34, 0x33, 0x33, 0x89, 0x67, 0x45, 0x33, 0x03, 0x16}
+	sp := &stubPort{reply: resp}
+	m := NewMeter(sp, "112233445566")
+	val, err := m.ReadEnergy(RatePeak)
+	if err != nil {
+		t.Fatalf("read energy: %v", err)
+	}
+	if math.Abs(val-1234.56) > 0.01 {
+		t.Fatalf("expect 1234.56 got %f", val)
+	}
+	// 校验请求报文
+	expectReq, _ := BuildReadFrame("112233445566", rateDataID[RatePeak])
+	if !bytes.Equal(expectReq, sp.written) {
+		t.Fatalf("unexpected request: %x", sp.written)
+	}
+}

--- a/pkg/dlt645/meter.go
+++ b/pkg/dlt645/meter.go
@@ -1,0 +1,47 @@
+package dlt645
+
+import (
+	"fmt"
+	"io"
+)
+
+// Meter 表示电表对象
+// 通过串口与电表通信
+// port 实现 io.ReadWriteCloser 接口, 例如 github.com/tarm/serial.Port
+// addr 为 12 位 BCD 地址
+//
+// 示例:
+//
+//	c, _ := serial.OpenPort(&serial.Config{Name: "/dev/ttyUSB0", Baud: 2400})
+//	m, _ := dlt645.NewMeter(c, "112233445566")
+//	val, _ := m.ReadEnergy(dlt645.RatePeak)
+type Meter struct {
+	port io.ReadWriteCloser
+	addr string
+}
+
+// NewMeter 创建 Meter 实例
+func NewMeter(port io.ReadWriteCloser, addr string) *Meter {
+	return &Meter{port: port, addr: addr}
+}
+
+// ReadEnergy 读取指定费率的电量(kWh)
+func (m *Meter) ReadEnergy(rate Rate) (float64, error) {
+	id, ok := rateDataID[rate]
+	if !ok {
+		return 0, fmt.Errorf("unsupported rate: %v", rate)
+	}
+	frame, err := BuildReadFrame(m.addr, id)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := m.port.Write(frame); err != nil {
+		return 0, err
+	}
+	buf := make([]byte, 256)
+	n, err := m.port.Read(buf)
+	if err != nil {
+		return 0, err
+	}
+	return ParseEnergyResponse(buf[:n])
+}


### PR DESCRIPTION
## Summary
- implement DL/T 645 protocol helpers for peak/flat/valley energy reading
- expose a REST API server wrapping serial communication and configurable via YAML
- document usage and add unit tests

## Testing
- `go mod tidy` *(fails: Forbidden to fetch modules)*
- `go test ./...` *(fails: missing go.sum entries)*
- `go test ./pkg/dlt645`

------
https://chatgpt.com/codex/tasks/task_e_68a1e3dc80b0832cbf5b787a7622f163